### PR TITLE
Update MOA.vhd

### DIFF
--- a/lib/hdl/MOA.vhd
+++ b/lib/hdl/MOA.vhd
@@ -34,6 +34,7 @@ architecture rtl of MOA is
   begin
     if (rising_edge(clk) and enable='1') then
       if (in_valid = '1') then
+          v_acc:= (others=>'0');
           acc_loop : for i in 0 to NUM_OPERANDS-1 loop
             v_acc := v_acc + in_data(i);
           end loop acc_loop;


### PR DESCRIPTION


There is a bug in this file: the variable v_acc is not reset to 0 in each new clock cycle to accumulate new set of values. Fixed by inlcuding
<  v_acc:= (others=>'0');  >  in line 37.